### PR TITLE
Add helmet and security headers optionally configured in .env

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,4 +1,20 @@
 NODE_ENV=development_or_staging_or_production
-PORT=5000
+PORT=choose_a_port
 AWS_KEY_ID=your_id
 AWS_SECRET_KEY=your_secret_key
+REQEUST_FROM_EMAIL=
+REQEUST_TO_EMAIL=
+REQEUST_TWEET_TO_EMAIL=
+REQEUST_TWEET_CC_EMAIL=
+
+
+# Disable HSTS? (set to 'true' to disable HSTS)
+HSTS_DISABLED='true'
+
+# Use Deny settings for X-Frame headers?
+# set to 'true' to disable X-frames-options denial
+DISABLE_XFO_HEADERS_DENY='false'
+
+# Use default XSS protection?
+# set to 'true' to disable IEXSS protection
+IEXSS_PROTECTION_DISABLED='false'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-watch": "0.5.3",
     "grunt-shell-spawn": "0.3.0",
     "grunt-cli": "0.1.13",
+    "helmet": "0.2.1",
     "nunjucks": "0.1.10"
   },
   "engines": {

--- a/server/config.js
+++ b/server/config.js
@@ -19,6 +19,22 @@ module.exports = function (env) {
   var app = express();
   // using a simple text file to store counter
   var counterFile = "counter.txt";
+  // Helmet for security headers and features
+  var helmet = require('helmet');
+
+  // Set up security header options based on .env settings
+  if (process.env.HSTS_DISABLED != 'true') {
+    // Use HSTS
+    app.use(helmet.hsts());
+  }
+  if (process.env.DISABLE_XFO_HEADERS_DENY != 'true') {
+    // No xframes allowed
+    app.use(helmet.xframe('deny'));
+  }
+  if (process.env.IEXSS_PROTECTION_DISABLED != 'true') {
+  // Use XSS protection
+    app.use(helmet.iexss());
+  }
 
   app.use(express.logger('dev'));
   app.use(express.compress());


### PR DESCRIPTION
Hi Mavis!

This adds some security features to the app, configured within the .env.  

Specifically, it allows us these:
X-FRAME-OPTIONS:DENY
X-Powered-By:Express
X-XSS-Protection:1; mode=block
As well as HSTS (not for us, not without https)

https://bugzilla.mozilla.org/show_bug.cgi?id=1018398 is the bug I'm working on this for.
